### PR TITLE
Add endpoint for setting up a pg dump of data associated with a singl…

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,28 +2,28 @@ require("dotenv").config();
 
 const express = require("express");
 const app = express();
-const morgan = require("morgan")
-const cors = require("cors")
+const morgan = require("morgan");
+const cors = require("cors");
 
-const pg = require('./models/pg_client')
-const errorHandler = require('./middleware/errorHandler')
-const unknownEndpoint = require('./middleware/unknownEndpoint')
+const pg = require('./models/pg_client');
+const errorHandler = require('./middleware/errorHandler');
+const unknownEndpoint = require('./middleware/unknownEndpoint');
 
-app.use(cors())
-app.use(express.json())
+app.use(cors());
+app.use(express.json());
 
 // connect to database
-pg.checkConnection()
+pg.checkConnection();
 
 // logging
 app.use(morgan("tiny"));
 
 // router API
-const testsController = require('./controllers/tests')
-app.use("/tests", testsController)
+const testsController = require('./controllers/tests');
+app.use("/tests", testsController);
 
 // error handling
-app.use(unknownEndpoint)
-app.use(errorHandler)
+app.use(unknownEndpoint);
+app.use(errorHandler);
 
-module.exports = app
+module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -1,74 +1,108 @@
-const request = require("supertest")
-const app = require('./app.js')
+const request = require("supertest");
+const app = require('./app.js');
 
 describe("/tests path", () => {
   test("GET method responds with 200", async () => {
-    const response = await request(app).get("/tests")
-    expect(response.statusCode).toBe(200)
-  })
+    const response = await request(app).get("/tests");
+    expect(response.statusCode).toBe(200);
+  });
 
   test("GET method returns JSON array", async () => {
-    const response = await request(app).get("/tests")
-    expect(Array.isArray(response.body)).toBe(true)
-  })
+    const response = await request(app).get("/tests");
+    expect(Array.isArray(response.body)).toBe(true);
+  });
 
   test("POST method responds with 201", async () => {
-    const response = await request(app).post("/tests")
-    const { id } = response.body
-    expect(response.statusCode).toBe(201)
-    await request(app).delete(`/tests/${id}`)
-  })
+    const response = await request(app).post("/tests");
+    const { id } = response.body;
+    expect(response.statusCode).toBe(201);
+    await request(app).delete(`/tests/${id}`);
+  });
 
   test("POST method creates newly created test with correct properties", async () => {
-    const response = await request(app).post("/tests")
-    const { id } = response.body
-    expect(response.body).toHaveProperty('id')
-    expect(response.body).toHaveProperty('name')
-    expect(response.body).toHaveProperty('start_time')
-    expect(response.body).toHaveProperty('end_time')
-    expect(response.body).toHaveProperty('status')
-    expect(response.body).toHaveProperty('script')
-    await request(app).delete(`/tests/${id}`)
-  })
+    const response = await request(app).post("/tests");
+    const { id } = response.body;
+    expect(response.body).toHaveProperty('id');
+    expect(response.body).toHaveProperty('name');
+    expect(response.body).toHaveProperty('start_time');
+    expect(response.body).toHaveProperty('end_time');
+    expect(response.body).toHaveProperty('status');
+    expect(response.body).toHaveProperty('script');
+    expect(response.body).toHaveProperty('archive_id');
+    await request(app).delete(`/tests/${id}`);
+  });
 
   test("POST method can create a test with a custom name, if given", async () => {
-    const response = await request(app).post("/tests").send({ name: "My Jest Test"})
-    const { id } = response.body
-    expect(response.body).toHaveProperty('name', 'My Jest Test')
-    await request(app).delete(`/tests/${id}`)
-  })
+    const response = await request(app).post("/tests").send({ name: "My Jest Test"});
+    const { id } = response.body;
+    expect(response.body).toHaveProperty('name', 'My Jest Test');
+    await request(app).delete(`/tests/${id}`);
+  });
 
   test("POST method responds with 400 and error message with non-unique name", async () => {
-    const response1 = await request(app).post("/tests").send({ name: "not unique"})
-    const { id } = response1.body
-    const response2 = await request(app).post("/tests").send({ name: "not unique"})
-    expect(response2.statusCode).toBe(400)
+    const response1 = await request(app).post("/tests").send({ name: "not unique"});
+    const { id } = response1.body;
+    const response2 = await request(app).post("/tests").send({ name: "not unique"});
+    expect(response2.statusCode).toBe(400);
     expect(response2.body).toHaveProperty(
       'error',
       'Invalid or malformed data. Hint: Names must be unique and no longer than 80 chars'
     );
     await request(app).delete(`/tests/${id}`);
-  })
+  });
 
   test("POST method response with 400 and error message with too long name", async () => {
     const name =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ';
-    const response = await request(app).post("/tests").send({ name })
-    expect(response.statusCode).toBe(400)
+    const response = await request(app).post("/tests").send({ name });
+    expect(response.statusCode).toBe(400);
     expect(response.body).toHaveProperty(
       'error',
       'Invalid or malformed data. Hint: Names must be unique and no longer than 80 chars'
     );
-  })
-})
+  });
+});
+
+describe("/tests/pg_dump/:testName path", () => {
+  let id;
+  const sampleName = "example";
+
+  beforeAll(async () => {
+    const response = await request(app).post("/tests").send({ name: sampleName });
+    id = response.body.id;
+  });
+
+  test("POST method returns 400 & error message that there is no data associated with incorrect test name", async () => {
+    const fakeName = "this_test_name_does_not_exist";
+    const response = await request(app).post(`/tests/pg_dump/${fakeName}`);
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toHaveProperty(
+      'error',
+      `Cannot perform pg dump for the test: ${fakeName}, as there is no data associated with this test name.`
+    );
+  });
+
+  test("POST method returns 201 & success message that data pg dump was successfully completed as data is inserted into pg dump specific tables", async () => {
+    const response = await request(app).post(`/tests/pg_dump/${sampleName}`);
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toHaveProperty(
+      'success',
+      `Completed setup of pg dump for the test: ${sampleName}`
+    );
+  });
+
+  afterAll(async () => {
+    await request(app).delete(`/tests/${id}`);
+  });
+});
 
 describe("/tests/:id path", () => {
   let id;
 
   beforeAll(async () => {
-    const response = await request(app).post("/tests")
-    id = response.body.id
-  })
+    const response = await request(app).post("/tests");
+    id = response.body.id;
+  });
 
   test('GET method responds with 200', async () => {
     const response = await request(app).get(`/tests/${id}`);
@@ -76,88 +110,95 @@ describe("/tests/:id path", () => {
   });
 
   test("GET method returns a test object with valid id", async () => {
-    const response = await request(app).get(`/tests/${id}`)
-    expect(response.body).toHaveProperty('id', id)
-  })
+    const response = await request(app).get(`/tests/${id}`);
+    expect(response.body).toHaveProperty('id', id);
+  });
 
   test("GET method returns 404 with error message with invalid id", async () => {
-    const response = await request(app).get(`/tests/999999`)
-    expect(response.statusCode).toBe(404)
+    const response = await request(app).get(`/tests/999999`);
+    expect(response.statusCode).toBe(404);
     expect(response.body).toHaveProperty(
       'error',
       'Nonexistent or malformed test id'
-    )
-  })
+    );
+  });
 
-  test("PUT method responds with 200", async () => {
+  test("PATCH method responds with 200", async () => {
     const response = await request(app)
-      .put(`/tests/${id}`)
+      .patch(`/tests/${id}`)
       .send({ name: 'change name' });
     expect(response.statusCode).toBe(200);
-  })
+  });
 
-  test("PUT method responds with changed name, when given", async () => {
+  test("PATCH method responds with changed name, when given", async () => {
     const response = await request(app)
-      .put(`/tests/${id}`)
+      .patch(`/tests/${id}`)
       .send({ name: 'change name again' });
-    expect(response.body).toHaveProperty('name', 'change name again')
-  })
+    expect(response.body).toHaveProperty('name', 'change name again');
+  });
 
-  test("PUT method responds with changed status, when given", async () => {
+  test("PATCH method responds with changed status, when given", async () => {
     const response = await request(app)
-      .put(`/tests/${id}`)
+      .patch(`/tests/${id}`)
       .send({ status: 'running' });
-    expect(response.body).toHaveProperty('status', 'running')
-  })
+    expect(response.body).toHaveProperty('status', 'running');
+  });
 
-  test("PUT method automatically assigns end_time when status is set to 'completed'", async () => {
+  test("PATCH method responds with changed archive_id attribute, when given", async () => {
     const response = await request(app)
-      .put(`/tests/${id}`)
-      .send({ status: 'completed' })
-    expect(response.body).toHaveProperty('status', 'completed')
-    expect(response.body.end_time).toBeTruthy()
-  })
+      .patch(`/tests/${id}`)
+      .send({ archive_id: "random_string_id" });
+    expect(response.body).toHaveProperty('archive_id', 'random_string_id');
+  });
 
-  test("PUT method responds with 404 and error message with invalid id", async () => {
+  test("PATCH method automatically assigns end_time when status is set to 'completed'", async () => {
     const response = await request(app)
-      .put(`/tests/999999`)
+      .patch(`/tests/${id}`)
+      .send({ status: 'completed' });
+    expect(response.body).toHaveProperty('status', 'completed');
+    expect(response.body.end_time).toBeTruthy();
+  });
+
+  test("PATCH method responds with 404 and error message with invalid id", async () => {
+    const response = await request(app)
+      .patch(`/tests/999999`)
       .send({ status: 'test' })
     expect(response.statusCode).toBe(404);
     expect(response.body).toHaveProperty(
       'error',
       'Nonexistent or malformed test id'
     );
-  })
+  });
 
-  test("PUT method responds with 400 and error message with invalid body", async () => {
-    const response = await request(app).put(`/tests/${id}`)
-    expect(response.statusCode).toBe(400)
+  test("PATCH method responds with 400 and error message with invalid body", async () => {
+    const response = await request(app).patch(`/tests/${id}`);
+    expect(response.statusCode).toBe(400);
     expect(response.body).toHaveProperty(
       'error',
       'Invalid or malformed data.'
-    )
-  })
+    );
+  });
 
   test("DELETE method responds with 204", async () => {
-    const res = await request(app).post('/tests')
-    const idToDelete = res.body.id
+    const res = await request(app).post('/tests');
+    const idToDelete = res.body.id;
 
-    const response = await request(app).delete(`/tests/${idToDelete}`)
-    expect(response.statusCode).toBe(204)
-  })
+    const response = await request(app).delete(`/tests/${idToDelete}`);
+    expect(response.statusCode).toBe(204);
+  });
 
   test("DELETE method should delete the associated test", async() => {
     const response = await request(app).post('/tests');
     const idToDelete = response.body.id;
 
-    await request(app).delete(`/tests/${idToDelete}`)
-    const res = await request(app).get('/tests')
-    const tests = res.body
-    const ids = tests.map(test => test.id)
-    expect(ids).not.toContain(idToDelete)
-  })
+    await request(app).delete(`/tests/${idToDelete}`);
+    const res = await request(app).get('/tests');
+    const tests = res.body;
+    const ids = tests.map(test => test.id);
+    expect(ids).not.toContain(idToDelete);
+  });
 
   afterAll(async () => {
-    await request(app).delete(`/tests/${id}`)
-  })
-})
+    await request(app).delete(`/tests/${id}`);
+  });
+});

--- a/controllers/tests.js
+++ b/controllers/tests.js
@@ -1,4 +1,4 @@
-const tests = require('../models/tests')
+const tests = require('../models/tests');
 
 const express = require('express');
 const { invalidName } = require('../models/tests');
@@ -6,29 +6,50 @@ const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const test_ids = await tests.getAll()
-    res.status(200).json(test_ids)
+    const test_ids = await tests.getAll();
+    res.status(200).json(test_ids);
   } catch (error) {
-    res.status(500).send(error)
+    res.status(500).send(error);
   }
-})
+});
 
 router.get('/:id', async (req, res) => {
-  const { id } = req.params
+  const { id } = req.params;
   try {
-    const test = await tests.get(id)
+    const test = await tests.get(id);
     if (test === undefined) {
-      res.status(404).send({ error: "Nonexistent or malformed test id" })
+      res.status(404).send({ error: "Nonexistent or malformed test id" });
     } else {
-      res.status(200).json(test)
+      res.status(200).json(test);
     }
   } catch (error) {
-    res.status(500).send(error)
+    res.status(500).send(error);
   }
-})
+});
+
+router.post('/pg_dump/:testName', async (req, res) => {
+  const { testName } = req.params;
+  let msg;
+  const dataExists = await tests.nameExists(testName);
+  if (!dataExists) {
+    msg = `Cannot perform pg dump for the test: ` + 
+      `${testName}, as there is no data associated ` +
+      `with this test name.`;
+    res.status(400).send({ error: msg });
+  } else {
+    try {
+      await tests.setUpPgDump(testName);
+      msg = `Completed setup of pg dump for the test: ${testName}`;
+      res.status(201).send({ success: msg });
+    } catch (error) {
+      msg = `Issue setting up pg dump tables: ${error.message}`;
+      res.status(500).send({ error: msg });
+    }
+  }
+});
 
 router.post('/', async (req, res) => {
-  const data = req.body
+  const data = req.body;
 
   if (!data.name) {
     data.name = tests.createName();
@@ -39,27 +60,27 @@ router.post('/', async (req, res) => {
       { 
         error: 'Invalid or malformed data. Hint: Names must be unique and no longer than 80 chars' 
       }
-    )
+    );
   }
 
   if (data.script) {
-    data.script = tests.cleanScriptString(data.script)
+    data.script = tests.cleanScriptString(data.script);
   }
 
   try {
-    const id = await tests.create(data)
-    res.status(201).json(id)
+    const id = await tests.create(data);
+    res.status(201).json(id);
   } catch (error) {
-    res.status(500).send(error)
+    res.status(500).send(error);
   }
-})
+});
 
-router.put('/:id', async (req, res) => {
-  const { id } = req.params
-  const data = req.body
+router.patch('/:id', async (req, res) => {
+  const { id } = req.params;
+  const data = req.body;
 
   if (!tests.validKeys(data)) {
-    res.status(400).send({ error: "Invalid or malformed data."})
+    res.status(400).send({ error: "Invalid or malformed data."});
   } else if (data.name && await tests.invalidName(data.name)) {
     res.status(400).send({
       error:
@@ -77,17 +98,17 @@ router.put('/:id', async (req, res) => {
       res.status(500).send(error);
     }
   }
-})
+});
 
 router.delete('/:id', async (req, res) => {
-  const { id } = req.params
+  const { id } = req.params;
 
   try {
-    await tests.delete(id)
-    res.status(204).send()
+    await tests.delete(id);
+    res.status(204).send();
   } catch (error) {
-    res.status(500).send(error)
+    res.status(500).send(error);
   }
-})
+});
 
 module.exports = router;

--- a/models/pg_client.js
+++ b/models/pg_client.js
@@ -1,26 +1,27 @@
-require("dotenv").config()
+require("dotenv").config();
 
-const { Pool } = require("pg")
+const { Pool } = require("pg");
 
-const pool = new Pool()
+const pool = new Pool();
 
 module.exports = {
   query: async (text, params) => {
-    return pool.query(text, params)
+    return pool.query(text, params);
   },
+
   checkConnection: () => {
     pool.connect((err, client, release) => {
       if (err) {
-        console.error('Error connecting to PG: ', err.stack)
-        process.exit(1) // shut down container if no connection is made so we can attempt to restart
+        console.error('Error connecting to PG: ', err.stack);
+        process.exit(1); // shut down container if no connection is made so we can attempt to restart
       }
       client.query('SELECT NOW()', (err, result) => {
-        release()
+        release();
         if (err) {
-          return console.error('Error executing PG query: ', err.stack)
+          return console.error('Error executing PG query: ', err.stack);
         }
-        console.log(`Connected to PG: ${result.rows[0].now}`)
-      })
+        console.log(`Connected to PG: ${result.rows[0].now}`);
+      });
     })
   }
-}
+};


### PR DESCRIPTION
…e load test & jest tests for the new feature.

Since load tests can have a lot of data, and the database may have an unknown amount of tests, the new endpoint sets up a pg dump for one test at a time by creating empty copies of the existing tests and samples tables and then copying over that test's data into these temporary pg dump tables. The edamame CLI tool will manage the remaining part of the pg dump process using appropriate kubectl and aws cli commands in tandem with user input.