### PR TITLE
update archive endpoint to allow for query parameter that specifies t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,23 @@ Notes:
 
 ### Archiving a test in an AWS S3 Bucket
 
-`POST /tests/archive/:testName` -> Creates a tar file that's ultimately a compressed version of .csv files that contain Postgres data associated with one load test that was exported from the Postgres database via COPY SQL statements. Subsequently, it uploads the compressed file as an s3 object to an AWS s3 bucket for longer term storage. The storage class of the s3 object upload is standard infrequent access, which offers cheaper access relative to some other S3 object storage classes, but also quick retrieval when the user wants to restore the data. If a user wants to use AWS Glacier storage instead (for even cheaper AWS cold storage), they can change the storage class of the uploaded load test s3 objects through the AWS CLI or the AWS console.
+`POST /tests/archive/:testName?storage=<storage_class>` -> Creates a tar file that's ultimately a compressed version of .csv files that contain Postgres data associated with one load test that was exported from the Postgres database via COPY SQL statements. Subsequently, it uploads the compressed file as an s3 object to an AWS s3 bucket for longer term storage. The storage class query parameter is optional and if no class is provided, the default standard storage class will be used. <br/>
+
+- A user can select any of the following valid storage class options:
+
+> STANDARD (Standard)
+> REDUCED_REDUNDANCY (Reduced Redundancy)
+> STANDARD_IA (Standard Infrequent Access)
+> ONEZONE_IA (One Zone Infrequent Access)
+> INTELLIGENT_TIERING (Standard Intelligent-Tiering)
+> GLACIER (Glacier Flexible Retrieval)
+> DEEP_ARCHIVE (Glacier Deep Archive)
+> GLACIER_IR (Glacier Instant Retrieval)
+
+- The available storage options have different associated fees & availability SLAs. Some of the classes also have retrieval charges and minimum storage duration charges. Read more about the storage class options at the following links to ensure the right class is chosen for your storage needs.
+
+  > https://aws.amazon.com/s3/storage-classes/  
+  > https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html > <br />
 
 Example usage:
 `POST /tests/archive/50kVus`

--- a/src/__tests__/app.js
+++ b/src/__tests__/app.js
@@ -84,7 +84,7 @@ describe("AWS S3 import and export paths", () => {
     expect(response.statusCode).toBe(400);
     expect(response.body).toHaveProperty(
       "error",
-      `Couldn't find S3 object associated with test: ${fakeName}`
+      `Couldn't find S3 object associated with the test ${fakeName}`
     );
   });
 });

--- a/src/__tests__/archive.js
+++ b/src/__tests__/archive.js
@@ -12,14 +12,52 @@ test("Ensure appropriate functions are called when backing up load test data int
   await archive.exportToAWS(sampleTest.name);
   expect(tests.dataDump).toHaveBeenCalledTimes(1);
   expect(files.numBytes).toHaveBeenCalledTimes(1);
+  expect(files.cleanUpDir).toBeCalled();
   expect(aws.ensureS3BucketIsSetup).toHaveBeenCalledTimes(1);
   expect(aws.uploadToS3).toHaveBeenCalledTimes(1);
-  expect(files.cleanUpDir).toHaveBeenCalledTimes(1);
 });
 
-test("Ensure appropriate functions are called when downloading data from AWS S3", async () => {
-  await archive.importFromAWS(sampleTest.name);
-  expect(aws.downloadS3Object).toHaveBeenCalledTimes(1);
+test("Ensure appropriate functions are called when downloading data from AWS S3 to database", async () => {
+  const response = await archive.importToDatabase(sampleTest.name);
   expect(files.unZip).toHaveBeenCalledTimes(1);
   expect(tests.importFromCsv).toHaveBeenCalledTimes(1);
+  expect(files.cleanUpDir).toBeCalled();
+  expect(response.statusCode).toEqual(200);
+  expect(response.message.success).toEqual(
+    `Successfully imported the test ${sampleTest.name} from your AWS S3 Bucket.`
+  );
+});
+
+test("Check error is thrown if unexpected storage class is passed", async () => {
+  expect.assertions(1);
+  try {
+    await archive.prepStorageClass("random class");
+  } catch (error) {
+    expect(error.message).toEqual(
+      "Invalid storage class specified: random class"
+    );
+  }
+});
+
+test("Ensure default standard storage class is returned if storage class query parameter is undefined", async () => {
+  const storageClass = await archive.prepStorageClass(undefined);
+  expect(storageClass).toEqual("STANDARD");
+});
+
+test("Ensure passed in storage class is returned if it's valid", async () => {
+  const validClass = "REDUCED_REDUNDANCY";
+  const storageClass = await archive.prepStorageClass(validClass);
+  expect(storageClass).toEqual(validClass);
+});
+
+test("Ensure all expected AWS S3 storage classes are considered valid", async () => {
+  const validClasses = archive.storageClassRetrievalTypes;
+  expect(validClasses).toHaveProperty("STANDARD");
+  expect(validClasses).toHaveProperty("REDUCED_REDUNDANCY");
+  expect(validClasses).toHaveProperty("STANDARD_IA");
+  expect(validClasses).toHaveProperty("ONEZONE_IA");
+  expect(validClasses).toHaveProperty("INTELLIGENT_TIERING");
+  expect(validClasses).toHaveProperty("GLACIER");
+  expect(validClasses).toHaveProperty("DEEP_ARCHIVE");
+  expect(validClasses).toHaveProperty("GLACIER_IR");
 });

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -6,6 +6,8 @@ const INVALID_NAME_ERROR_MSG =
   "Invalid or malformed data. Hint: Names must be unique and no longer than 80 chars";
 const GET_TEST_ERROR_MSG = "Unable to retrieve test information";
 const BAD_ID_ERROR_MSG = "Nonexistent or malformed test id";
+const DEFAULT_STORAGE_CLASS = "STANDARD";
+const DUPLICATE_IMPORT = "Can't import duplicate load test information";
 
 export {
   CLUSTER_NAME,
@@ -15,4 +17,6 @@ export {
   INVALID_NAME_ERROR_MSG,
   GET_TEST_ERROR_MSG,
   BAD_ID_ERROR_MSG,
+  DEFAULT_STORAGE_CLASS,
+  DUPLICATE_IMPORT,
 };

--- a/src/models/archive.js
+++ b/src/models/archive.js
@@ -1,37 +1,105 @@
 import aws from "./aws.js";
 import files from "./files.js";
 import tests from "./tests.js";
-import { SINGLE_UPLOAD_MAX_SIZE } from "../constants/constants.js";
+import {
+  SINGLE_UPLOAD_MAX_SIZE,
+  DEFAULT_STORAGE_CLASS,
+  ARCHIVE,
+} from "../constants/constants.js";
 
 const archive = {
-  exportToAWS: async (test) => {
-    const uploadFile = tests.s3ObjectNameForTest(test.name);
-    await tests.dataDump(test.id, uploadFile);
-    const uploadSize = await files.numBytes(`/var/pg_dump/${uploadFile}`);
+  exportToAWS: async (test, storageClass) => {
+    try {
+      const storage = archive.prepStorageClass(storageClass);
+      const uploadFile = tests.s3ObjectNameForTest(test.name);
+      await tests.dataDump(test.id, uploadFile);
+      const uploadSize = await files.numBytes(`/var/pg_dump/${uploadFile}`);
 
-    if (uploadSize > SINGLE_UPLOAD_MAX_SIZE) {
-      let msg =
-        `Archiving ${test.name} requires uploading more parts` +
-        ` than the 10,000 subpart upload limit. Aborting archival.`;
+      if (uploadSize > SINGLE_UPLOAD_MAX_SIZE) {
+        throw new Error(archive.uploadSizeIssueMsg(test.name));
+      }
+      await aws.ensureS3BucketIsSetup(uploadFile);
+      await aws.uploadToS3(`/var/pg_dump/${uploadFile}`, storage);
       files.cleanUpDir("/var/pg_dump/");
-      throw new Error(msg);
+    } catch (error) {
+      files.cleanUpDir("/var/pg_dump/");
+      throw new Error(error);
     }
-    await aws.ensureS3BucketIsSetup(uploadFile);
-    await aws.uploadToS3(`/var/pg_dump/${uploadFile}`);
-    files.cleanUpDir("/var/pg_dump/");
   },
 
   importFromAWS: async (testName) => {
     try {
       const s3ObjectName = tests.s3ObjectNameForTest(testName);
-      await aws.downloadS3Object(s3ObjectName);
-      await files.unZip(s3ObjectName);
-      await tests.importFromCsv();
-      files.cleanUpDir("/var/pg_dump/");
+      const result = await aws.downloadS3Object(s3ObjectName);
+      if (result.stdout.match("restore")) {
+        return {
+          statusCode: 400,
+          message: { error: archive.importSuccessMsg(testName) },
+        };
+      } else {
+        const response = await archive.importToDatabase(testName, s3ObjectName);
+        return response;
+      }
     } catch (error) {
       files.cleanUpDir("/var/pg_dump/");
       throw Error(error);
     }
+  },
+
+  importToDatabase: async (testName, s3ObjectName) => {
+    await files.unZip(s3ObjectName);
+    await tests.importFromCsv();
+    files.cleanUpDir("/var/pg_dump/");
+    return {
+      statusCode: 200,
+      message: { success: archive.importSuccessMsg(testName) },
+    };
+  },
+
+  storageClassRetrievalTypes: {
+    STANDARD: "immediate",
+    REDUCED_REDUNDANCY: "immediate",
+    STANDARD_IA: "immediate",
+    ONEZONE_IA: "immediate",
+    INTELLIGENT_TIERING: "immediate",
+    GLACIER: "restore_first",
+    DEEP_ARCHIVE: "restore_first",
+    GLACIER_IR: "immediate",
+  },
+
+  nonexistentTestMsg(testName) {
+    return `Cannot archive a nonexistent test: ${testName}`;
+  },
+
+  prepStorageClass: (storageClass) => {
+    if (storageClass === undefined) {
+      return DEFAULT_STORAGE_CLASS;
+    }
+
+    if (archive.storageClassRetrievalTypes.hasOwnProperty(storageClass)) {
+      return storageClass;
+    } else {
+      throw Error(`Invalid storage class specified: ${storageClass}`);
+    }
+  },
+
+  importSuccessMsg: (testName) => {
+    return `Successfully imported the test ${testName} from your AWS S3 Bucket.`;
+  },
+
+  uploadSuccessMsg: (testName) => {
+    return `Successfully archived test ${testName} in your ${ARCHIVE} AWS S3 Bucket.`;
+  },
+
+  unknownObjectMsg: (testName) => {
+    return `Couldn't find S3 object associated with the test ${testName}`;
+  },
+
+  uploadSizeIssueMsg: (testName) => {
+    return (
+      `Archiving ${testName} requires uploading more parts` +
+      ` than the 10,000 subpart upload limit. Aborting archival.`
+    );
   },
 };
 

--- a/src/models/aws.js
+++ b/src/models/aws.js
@@ -45,7 +45,7 @@ const aws = {
   },
 
   downloadS3Object: async (objectName) => {
-    await exec(
+    return exec(
       `cd /var/pg_dump && aws s3 cp s3://${ARCHIVE}/${objectName} ./${objectName}`
     );
   },
@@ -64,9 +64,9 @@ const aws = {
     }
   },
 
-  uploadToS3: async (filePath) => {
+  uploadToS3: async (filePath, storageClass) => {
     await exec(
-      `aws s3 mv ${filePath} s3://${ARCHIVE} --storage-class STANDARD_IA`
+      `aws s3 mv ${filePath} s3://${ARCHIVE} --storage-class ${storageClass}`
     );
   },
 };


### PR DESCRIPTION
…he desired AWS S3 storage class; update readme and test suite

Accept all of the possible AWS CLI storage options (standard, reduced redundancy standard IA, onezone IA, intelligent tiering, glacier, deep archive, glacier instant retrieval)

If no storage query parameter is provided set the default selection to standard to avoid minimum storage duration charges and retrieval charges that some other tiers have.

